### PR TITLE
Added id field to parking lots response

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,7 @@ Content-Type: application/json
 {
     "data": [
         {
+            "id": "64c9e920e9b30105a42ee879",
             "latitude": "44.56298278509426",
             "longitude": "-123.27235573138302",
             "parking_lot_name": "Tebeau Hall",

--- a/app.js
+++ b/app.js
@@ -2,7 +2,6 @@ const express = require('express');
 const mongoose = require('mongoose');
 const parkingLotRouter = require('./route/ParkingLotRoute');
 const config = require('./config');
-const scheduler = require('./scheduler/CleanUpDbScheduler');
 
 const url = config.mongo.connection_string;
 let maxTries = 0;

--- a/model/RecentParkingLots.js
+++ b/model/RecentParkingLots.js
@@ -2,6 +2,7 @@ const mongoose = require('mongoose');
 const Schema = mongoose.Schema;
 
 const recentParkingLotSchema = new Schema({
+    id: String,
     latitude: String,
     longitude: String,
     name: String,

--- a/service/ParkingLotService.js
+++ b/service/ParkingLotService.js
@@ -12,6 +12,7 @@ exports.getAllRecentParkingLots = async () => {
 
     return recentParkingLots.map((parkingLot) => {
         return {
+            id: parkingLot._id,
             latitude: parkingLot.latitude,
             longitude: parkingLot.longitude,
             parking_lot_name: parkingLot.name,

--- a/test/ParkingLotTest.js
+++ b/test/ParkingLotTest.js
@@ -83,6 +83,7 @@ function cleanUpDatabase() {
 function populateDummyRecords() {
     const bufferOne = fs.readFileSync(__dirname + '/Parking lot one.jpeg');
     parkingLotOne = new RecentParkingLot({
+            id: '55544f13-fbc4-434a-b0c2-d9428e24163f',
             latitude: '51.22',
             longitude: '-51.22',
             name: 'Lot 1',
@@ -97,6 +98,7 @@ function populateDummyRecords() {
 
     const bufferTwo = fs.readFileSync(__dirname + '/Parking lot two.jpeg');
     parkingLotTwo = new RecentParkingLot({
+            id: '45544f13-fbc4-434a-b0c2-d9428e24162f',
             latitude: '41.22',
             longitude: '-41.22',
             name: 'Lot 2',


### PR DESCRIPTION
# Proposed Changes

The current response of `/parking_lots` API doesn’t have an “id” field. So, an “id” field has been added to be inline with the REST architecture.

# Jira Stories

- [LAB-439](https://oregonstate-innovationlab.atlassian.net/browse/LAB-439)

# Checklist

- [x] This has been tested
- [x] Self-documenting code
- [x] Code is linted

# Instructions to review

Follow the local/dev setup instructions in the [README](https://github.com/subramanya1702/Smart-Park#localdev-setup) to bring up the application locally. Check if the response of `/parking_lots` API has an "id" field included in every parking lot.
